### PR TITLE
Pass context to the Repository as well

### DIFF
--- a/cmd/rest-memory-service/main.go
+++ b/cmd/rest-memory-service/main.go
@@ -14,7 +14,7 @@ func main() {
 	ctx, cancelFn := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancelFn()
 
-	portsRepo := memory.NewStorage()
+	portsRepo := memory.NewStorage(ctx)
 	portsApp := application.NewPorts(portsRepo)
 	httpSrv := http.NewServer(portsApp)
 

--- a/pkg/infrastructure/repository/memory/memory.go
+++ b/pkg/infrastructure/repository/memory/memory.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"sync"
 
 	"github.com/google/uuid"
@@ -12,7 +13,7 @@ type Storage struct {
 	data   map[string]domain.Port
 }
 
-func NewStorage() *Storage {
+func NewStorage(_ context.Context) *Storage {
 	return &Storage{
 		data: map[string]domain.Port{},
 	}

--- a/pkg/infrastructure/repository/mongo/mongo.go
+++ b/pkg/infrastructure/repository/mongo/mongo.go
@@ -1,27 +1,32 @@
 package mongo
 
 import (
+	"context"
+
 	"github.com/lootek/go-port-service/pkg/core/domain"
 )
 
 type DB struct {
 }
 
-func NewDB() *DB {
+func NewDB(_ context.Context) *DB {
 	return &DB{}
 }
 
 func (D DB) GetAll() []domain.Port {
 	// TODO implement me
+	// Remember to create the new ctx for a db call request deriving from the main ctx
 	panic("implement me")
 }
 
 func (D DB) Insert(port domain.Port) error {
 	// TODO implement me
+	// Remember to create the new ctx for a db call request deriving from the main ctx
 	panic("implement me")
 }
 
 func (D DB) Update(id string, port domain.Port) error {
 	// TODO implement me
+	// Remember to create the new ctx for a db call request deriving from the main ctx
 	panic("implement me")
 }

--- a/pkg/infrastructure/service/http/server.go
+++ b/pkg/infrastructure/service/http/server.go
@@ -37,7 +37,7 @@ func (s *Server) Run(ctx context.Context) {
 	s.srvShutdown = func() {
 		err := srv.Shutdown(ctx)
 		if err != nil {
-			log.Printf("HTTP server shutdown failed: %s\n", err)
+			log.Printf("HTTP server graceful shutdown failed: %s\n", err)
 		}
 	}
 
@@ -47,7 +47,7 @@ func (s *Server) Run(ctx context.Context) {
 	s.httpRouter.PUT("/ports/:id", s.Update)
 
 	go func() {
-		if err := srv.ListenAndServe(); err != nil {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Printf("HTTP server error: %s\n", err)
 		}
 	}()


### PR DESCRIPTION
* Pass context to the Repository as well
* Better error handling for HTTP server

see
* #3